### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(robot_pose_ekf)
 
 # bfl (Bayesian Filtering Library) is a third party package that uses pkg-config


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

example:
```
==> Processing catkin package: 'robot_pose_ekf'
==> Building with env: '/home/sloretz/ws/noetic-misc/devel_isolated/tf/env.sh'
==> cmake /home/sloretz/ws/noetic-misc/src/robot_pose_ekf -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/noetic-misc/devel_isolated/robot_pose_ekf -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/noetic-misc/install_isolated -G Unix Makefiles in '/home/sloretz/ws/noetic-misc/build_isolated/robot_pose_ekf'
CMake Warning (dev) at CMakeLists.txt:2 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

ros/catkin#1052