### PR TITLE
Replace bfl ROS package with rosdep keys

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
 
     <build_depend>message_generation</build_depend>
     <build_depend>roscpp</build_depend>
-    <build_depend>bfl</build_depend>
+    <build_depend>liborocos-bfl-dev</build_depend>
     <build_depend>std_msgs</build_depend>
     <build_depend>geometry_msgs</build_depend>
     <build_depend>sensor_msgs</build_depend>
@@ -26,7 +26,7 @@
 
     <run_depend>message_runtime</run_depend>
     <run_depend>roscpp</run_depend>
-    <run_depend>bfl</run_depend>
+    <run_depend>liborocos-bfl</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>geometry_msgs</run_depend>
     <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
I tested this package using a system install of `liborocos-bfl-dev` on Debian Buster and Ubuntu Focal and the tests seem to pass. This PR replaces `bfl` with to-be-added rosdep keys. This PR makes the `master` branch work for ROS Noetic only. If multiple ROS distros on the same branch is desired, then I think the package.xml would need to be upgraded to format 3 and conditional dependencies on `ROS_DISTRO` would need to be used.

See also https://github.com/ros/rosdistro/pull/23841 and https://github.com/ros-gbp/bfl-release/issues/12