### PR TITLE
Fix when only IMU is active and gps is not active

### DIFF
--- a/src/odom_estimation_node.cpp
+++ b/src/odom_estimation_node.cpp
@@ -487,6 +487,10 @@ namespace estimation
         my_filter_.initialize(vo_meas_, vo_stamp_);
         ROS_INFO("Kalman filter initialized with vo measurement");
       }
+      else if ( imu_active_ && !gps_used_ && !my_filter_.isInitialized()){
+        my_filter_.initialize(imu_meas_, imu_stamp_);
+        ROS_INFO("Kalman filter initialized with imu measurement");
+      }
     }
   };
 


### PR DESCRIPTION
Looks like IMU part of the code was broken when adding gps fix into it. This is related to bug #23 